### PR TITLE
use specific version numbers on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ os:
   - linux
   - osx
 julia:
-  - release
+  - 0.4
+  - 0.5
+  - 0.6
   - nightly
 notifications:
   email: false


### PR DESCRIPTION
release is 0.5 (for a little longer), but 0.4 is still supported here according to REQUIRE
so should still be tested