### PR TITLE
Update definition of < operator

### DIFF
--- a/src/DoubleDouble.jl
+++ b/src/DoubleDouble.jl
@@ -102,9 +102,8 @@ Double(x::BigFloat) = convert(Double{Float64}, x)
 Double(x::Irrational) = convert(Double{Float64}, x)
 
 # <
-
 function <{T}(x::Double{T}, y::Double{T})
-    x.hi + x.lo < y.hi + y.lo
+    x.hi < y.hi || (x.hi == y.hi && x.lo < y.lo)
 end
 
 # add12

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,6 +41,9 @@ bxy = bx*by
 
 #@test rem(dxy,1.0) == Double(rem(bxy,1.0))
 
+let x = Double(big"3.1")
+    @test Double(x.hi, prevfloat(x.lo)) < x < Double(x.hi, nextfloat(x.lo))
+end
 
 ## New
 @test Double(pi) == Double{Float64}(3.141592653589793, 1.2246467991473532e-16)


### PR DESCRIPTION
With current definition of <:
```
x = Double(Float64(pi))
y = Double(pi)

BigFloat(x) < BigFloat(pi) < BigFloat(y)  # true
x < y     # false
x == y    # false
x > y     # false
```